### PR TITLE
Improved object name escaping when exporting to ZBrush

### DIFF
--- a/GoB_2_8.py
+++ b/GoB_2_8.py
@@ -564,8 +564,7 @@ class GoB_OT_export(bpy.types.Operator):
         GoZ_ObjectList = open("{0}/GoZBrush/GoZ_ObjectList.txt".format(PATHGOZ), 'wt')
         for obj in scn.objects:
             if obj.type == 'MESH' and obj.select_get():
-                obj.name = obj.name.replace('.', '_')
-                obj.name = obj.name.replace(' ', '_')
+                obj.name = self.escape_object_name(obj.name)
                 bpy.ops.object.mode_set(mode='OBJECT')
                 self.exportGoZ(
                     PATHGOZ, scn, obj,
@@ -584,6 +583,15 @@ class GoB_OT_export(bpy.types.Operator):
 
     def invoke(self, context, event):
         return self.execute(context)
+
+    def escape_object_name(self, name):
+        """
+        Escape object name so it can be used as a valid file name.
+        Keep only alphanumeric characters, underscore, dash and dot, and replace other characters with an underscore.
+        Multiple consecutive invalid characters will be replaced with just a single underscore character.
+        """
+        import re
+        return re.sub('[^\w\_\-\.]+', '_', name)
 
 
 class GoB_OT_ModalTimerOperator(bpy.types.Operator):


### PR DESCRIPTION
When importing from MakeHuman (http://www.makehumancommunity.org) using MHX2, the object names contain a semicolon (':'). But Blender does not really limit object names to certain characters, which leads to invalid file names when exporting to ZBrush.

I have updated the algorithm which escapes and updates the object names when exporting to ZBrush. Now it allows only alphanumeric characters, underscore, dash and dot, and replaces all other 'invalid' characters with an underscore.