### PR TITLE
Bugfix/exception when texture is missing

### DIFF
--- a/GoB_2-72.py
+++ b/GoB_2-72.py
@@ -696,65 +696,71 @@ class GoB_export(bpy.types.Operator):
             if matslot.material:
                 GoBmat = matslot
                 break
-        if GoBmat:
-            for texslot in GoBmat.material.texture_slots:
-                if texslot:
-                    if texslot.texture:
-                        if texslot.texture.type == 'IMAGE' and texslot.texture_coords == 'UV' and texslot.texture.image:
-                            if texslot.use_map_color_diffuse:diff=texslot
-                            if texslot.use_map_displacement:disp=texslot
-                            if texslot.use_map_normal:nm=texslot
-        formatRender = scn.render.image_settings.file_format
-        scn.render.image_settings.file_format = 'BMP'
-        if diff:
-            name = diff.texture.image.filepath.replace('\\','/')
-            name = name.rsplit('/')[-1]
-            name = name.rsplit('.')[0]
-            if len(name) > 5:
-                if name[-5:] == "_TXTR":
-                    name = path + '/GoZProjects/Default/' + name + '.bmp'
-                else:
-                    name = path + '/GoZProjects/Default/' + name + '_TXTR.bmp'
-            diff.texture.image.save_render(name)
-            print(name)
-            name = name.encode('utf8')
-            fic.write(pack('<4B',0xc9,0xaf,0x00,0x00))
-            fic.write(pack('<I',len(name)+16))
-            fic.write(pack('<Q',1))
-            fic.write(pack('%ss'%len(name),name))
-        if disp:
-            name = disp.texture.image.filepath.replace('\\','/')
-            name = name.rsplit('/')[-1]
-            name = name.rsplit('.')[0]
-            if len(name) > 3:
-                if name[-3:] == "_DM":
-                    name = path + '/GoZProjects/Default/' + name + '.bmp'
-                else:
-                    name = path + '/GoZProjects/Default/' + name + '_DM.bmp'
-            disp.texture.image.save_render(name)
-            print(name)
-            name = name.encode('utf8')
-            fic.write(pack('<4B',0xd9,0xd6,0x00,0x00))
-            fic.write(pack('<I',len(name)+16))
-            fic.write(pack('<Q',1))
-            fic.write(pack('%ss'%len(name),name))
-        if nm:
-            name = nm.texture.image.filepath.replace('\\','/')
-            name = name.rsplit('/')[-1]
-            name = name.rsplit('.')[0]
-            if len(name) > 3:
-                if name[-3:] == "_NM":
-                    name = path + '/GoZProjects/Default/' + name + '.bmp'
-                else:
-                    name = path + '/GoZProjects/Default/' + name + '_NM.bmp'
-            nm.texture.image.save_render(name)
-            print(name)
-            name = name.encode('utf8')
-            fic.write(pack('<4B',0x51,0xc3,0x00,0x00))
-            fic.write(pack('<I',len(name)+16))
-            fic.write(pack('<Q',1))
-            fic.write(pack('%ss'%len(name),name))
-        # fin
+
+        try:    #see if we find textures
+            if GoBmat:
+                for texslot in GoBmat.material.texture_slots:
+                    if texslot:
+                        if texslot.texture:
+                                if texslot.texture.type == 'IMAGE' and texslot.texture_coords == 'UV' and texslot.texture.image:
+                                    if texslot.use_map_color_diffuse:diff=texslot
+                                    if texslot.use_map_displacement:disp=texslot
+                                    if texslot.use_map_normal:nm=texslot
+            formatRender = scn.render.image_settings.file_format
+            scn.render.image_settings.file_format = 'BMP'
+            if diff:
+                name = diff.texture.image.filepath.replace('\\','/')
+                name = name.rsplit('/')[-1]
+                name = name.rsplit('.')[0]
+                if len(name) > 5:
+                    if name[-5:] == "_TXTR":
+                        name = path + '/GoZProjects/Default/' + name + '.bmp'
+                    else:
+                        name = path + '/GoZProjects/Default/' + name + '_TXTR.bmp'
+                diff.texture.image.save_render(name)
+                print(name)
+                name = name.encode('utf8')
+                fic.write(pack('<4B',0xc9,0xaf,0x00,0x00))
+                fic.write(pack('<I',len(name)+16))
+                fic.write(pack('<Q',1))
+                fic.write(pack('%ss'%len(name),name))
+            if disp:
+                name = disp.texture.image.filepath.replace('\\','/')
+                name = name.rsplit('/')[-1]
+                name = name.rsplit('.')[0]
+                if len(name) > 3:
+                    if name[-3:] == "_DM":
+                        name = path + '/GoZProjects/Default/' + name + '.bmp'
+                    else:
+                        name = path + '/GoZProjects/Default/' + name + '_DM.bmp'
+                disp.texture.image.save_render(name)
+                print(name)
+                name = name.encode('utf8')
+                fic.write(pack('<4B',0xd9,0xd6,0x00,0x00))
+                fic.write(pack('<I',len(name)+16))
+                fic.write(pack('<Q',1))
+                fic.write(pack('%ss'%len(name),name))
+            if nm:
+                name = nm.texture.image.filepath.replace('\\','/')
+                name = name.rsplit('/')[-1]
+                name = name.rsplit('.')[0]
+                if len(name) > 3:
+                    if name[-3:] == "_NM":
+                        name = path + '/GoZProjects/Default/' + name + '.bmp'
+                    else:
+                        name = path + '/GoZProjects/Default/' + name + '_NM.bmp'
+                nm.texture.image.save_render(name)
+                print(name)
+                name = name.encode('utf8')
+                fic.write(pack('<4B',0x51,0xc3,0x00,0x00))
+                fic.write(pack('<I',len(name)+16))
+                fic.write(pack('<Q',1))
+                fic.write(pack('%ss'%len(name),name))
+            # fin
+        except:
+            # continue without textures
+            pass
+
         scn.render.image_settings.file_format = formatRender
         fic.write(pack('16x'))
         fic.close()

--- a/GoB_2-72.py
+++ b/GoB_2-72.py
@@ -697,7 +697,7 @@ class GoB_export(bpy.types.Operator):
                 GoBmat = matslot
                 break
 
-        try:    #see if we find textures
+        try:
             if GoBmat:
                 for texslot in GoBmat.material.texture_slots:
                     if texslot:
@@ -758,7 +758,7 @@ class GoB_export(bpy.types.Operator):
                 fic.write(pack('%ss'%len(name),name))
             # fin
         except:
-            # continue without textures
+            # continue even when no textures are found
             pass
 
         scn.render.image_settings.file_format = formatRender


### PR DESCRIPTION
when a texture was missing there was a error and the transfer to zbrush did not work, i added a exception so the transfer also works with missing textures.

`search for unknown operator 'VIEW3D_OT_mode', 'VIEW3D_OT_mode'
Traceback (most recent call last):
  File "\addons\GoB_2-72.py", line 773, in invoke
    return self.execute(context)
  File "\addons\GoB_2-72.py", line 759, in execute
    '{0}/GoZProjects/Default'.format(PATHGOZ))
  File "\addons\GoB_2-72.py", line 701, in exportGoZ
    diff.texture.image.save_render(name)
RuntimeError: Error: Could not acquire buffer from image`