### PR TITLE
modifiers will be applied when render flag is enabled, so we can have…

### DIFF
--- a/GoB.py
+++ b/GoB.py
@@ -20,18 +20,6 @@ import bpy, mathutils, bl_ui, time, os
 from struct import pack,unpack
 from copy import deepcopy
 
-bl_info = {
-    "name": "GoB",
-    "description": "An unofficial GOZ-like for Blender",
-    "author": "ODe",
-    "version": (2, 72),
-    "blender": (2, 72, 0),
-    "location": "At the info header",
-    "wiki_url": "http://wiki.blender.org/index.php/Extensions:"
-		"2.6/Py/Scripts/Import-Export/GoB_ZBrush_import_export",
-    "tracker_url": "http://www.zbrushcentral.com/showthread.php?"
-		"127419-GoB-an-unofficial-GoZ-for-Blender",
-    "category": "Import-Export"}
 
 if os.path.isfile("C:/Users/Public/Pixologic/GoZBrush/GoZBrushFromApp.exe"):
     PATHGOZ = "C:/Users/Public/Pixologic"
@@ -860,21 +848,3 @@ class GoB_ModalTimerOperator(bpy.types.Operator):
         return {'CANCELLED'}
 
 
-def register():
-    bpy.utils.register_class(GoB_export)
-    bpy.utils.register_class(GoB_import)
-    bpy.utils.register_class(INFO_HT_header)
-    # bpy.utils.register_class(bl_ui.space_info.INFO_MT_editor_menus)
-    bpy.utils.register_class(GoB_ModalTimerOperator)
-
-def unregister():
-    import bl_ui
-
-    bpy.utils.unregister_class(GoB_export)
-    bpy.utils.unregister_class(GoB_import)
-    bpy.utils.unregister_class(INFO_HT_header)
-    bpy.utils.register_class(bl_ui.space_info.INFO_HT_header)
-    bpy.utils.unregister_class(GoB_ModalTimerOperator)
-
-if __name__ == "__main__":
-    if PATHGOZ:register()

--- a/GoB.py
+++ b/GoB.py
@@ -324,6 +324,7 @@ class GoB_import(bpy.types.Operator):
                     fic.seek(cnt,1)
                 tag = fic.read(4)
             fic.close()
+            bpy.ops.object.select_all(action='DESELECT')
             ob.select = True
             scn.objects.active = ob
             GoBmat = False
@@ -484,6 +485,7 @@ class GoB_import(bpy.types.Operator):
                     fic.seek(cnt,1)
                 tag = fic.read(4)
             fic.close()
+            bpy.ops.object.select_all(action='DESELECT')
             ob.select = True
             scn.objects.active = ob
             objMat = bpy.data.materials.new('GoB_{0}'.format(objName))

--- a/GoB.py
+++ b/GoB.py
@@ -584,11 +584,7 @@ class GoB_export(bpy.types.Operator):
                 ob.select = False
                 scn.objects.active = new_ob
 
-            else:
-                #bpy.ops.object.convert(target='MESH')   # TODO: this will apply modifiers, why is this here?
-                pass
-
-        me = ob.to_mesh(scn,False,'PREVIEW')
+        me = ob.to_mesh(scn,True,'RENDER')
         mat_transform = mathutils.Matrix([
                                 (1.,0., 0.,0.),
                                 (0.,0.,-1.,0.),

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,56 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+
+bl_info = {
+    "name": "GoB",
+    "description": "An unofficial GOZ-like for Blender",
+    "author": "ODe",
+    "version": (2, 72),
+    "blender": (2, 72, 0),
+    "location": "At the info header",
+    "wiki_url": "http://wiki.blender.org/index.php/Extensions:"
+		"2.6/Py/Scripts/Import-Export/GoB_ZBrush_import_export",
+    "tracker_url": "http://www.zbrushcentral.com/showthread.php?"
+		"127419-GoB-an-unofficial-GoZ-for-Blender",
+    "category": "Import-Export"}
+
+
+if "bpy" in locals():
+    import importlib
+    importlib.reload(GoB)
+else:
+    from . import GoB
+
+import bpy
+
+
+classes = (GoB.GoB_import,
+           GoB.GoB_export,
+           GoB.INFO_HT_header,
+           GoB.INFO_MT_editor_menus,
+           GoB.GoB_ModalTimerOperator,
+           )
+
+
+def register():
+    [bpy.utils.register_class(c) for c in classes]
+
+
+def unregister():
+    [bpy.utils.unregister_class(c) for c in classes]


### PR DESCRIPTION
I made a fix so we are able to chose if the modifiers are applied or not. 
It is decided by the render flag of the modifiers, his allows the user to see a modifier in blender but is able to send the object to zbrush without it if he chooses to.

Its not so obvious so maybe not the nicest solution but i think its worth having this flexibility.
