### PR TITLE
triangulation applied after modifiers; version bump

### DIFF
--- a/GoB.py
+++ b/GoB.py
@@ -379,22 +379,7 @@ def apply_modifiers(obj, pref):
     obj.select_set(state=False)
     bpy.context.view_layer.objects.active = obj_temp
 
-    # 2. apply triangulation to not crash zbrush
-    mod = obj_temp.modifiers.new("TriangulateNgons", 'TRIANGULATE')
-    mod.keep_custom_normals = False
-    mod.min_vertices = 5
-    mod.ngon_method = 'BEAUTY'
-    mod.quad_method = 'BEAUTY'
-    bpy.ops.object.modifier_apply(modifier='TriangulateNgons')
-
-    # quadrangulate triangulation
-    bpy.ops.object.mode_set(mode='EDIT', toggle=False)
-    bpy.ops.mesh.reveal()
-    bpy.ops.mesh.select_all(action='SELECT')
-    bpy.ops.mesh.tris_convert_to_quads()
-    bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
-
-    # 3. apply user modifier export choice
+    # 2. apply user modifier export choice
     if pref.modifiers == 'APPLY_EXPORT':
         me = obj_temp.to_mesh(bpy.context.depsgraph, apply_modifiers=True, calc_undeformed=False)
         obj_temp.data = me
@@ -403,6 +388,22 @@ def apply_modifiers(obj, pref):
         me = obj_temp.to_mesh(bpy.context.depsgraph, apply_modifiers=True, calc_undeformed=False)
     else:
         me = obj_temp.data
+
+    # 3. apply triangulation to not crash zbrush
+    mod = obj_temp.modifiers.new("TriangulateNgons", 'TRIANGULATE')
+    mod.keep_custom_normals = False
+    mod.min_vertices = 5
+    mod.ngon_method = 'BEAUTY'
+    mod.quad_method = 'BEAUTY'
+    bpy.ops.object.modifier_apply(modifier='TriangulateNgons')
+
+    # 4. quadrangulate triangulation
+    bpy.ops.object.mode_set(mode='EDIT', toggle=False)
+    bpy.ops.mesh.reveal()
+    bpy.ops.mesh.select_all(action='SELECT')
+    bpy.ops.mesh.tris_convert_to_quads()
+    bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+    me = obj_temp.data
 
     #  5. delete that dummy object and reselect the original
     bpy.ops.object.delete(use_global=True)

--- a/__init__.py
+++ b/__init__.py
@@ -33,7 +33,7 @@ bl_info = {
     "name": "GoB",
     "description": "An unofficial GOZ-like addon for Blender",
     "author": "ODe, JoseConseco, kromar",
-    "version": (3, 0, 0),
+    "version": (3, 0, 1),
     "blender": (2, 80, 0),
     "location": "In the info header",
     "wiki_url": "http://wiki.blender.org/index.php/Extensions:"


### PR DESCRIPTION
the triangulation will now apply after the modifiers. 
i looked into the issue you mentioned that the subdivision modifier does a triangulation, the issue here is that if the subsurf modifier applies the triangulation it will still change the triangulation once the mesh is sent back to blender so we end up with the same result.

we would need to keep the unchanged mesh before we transfer it and somehow restore the topology when it comes back. however since this is the most basic example and we do not know what the user does to the mesh in zbrush i do not think its realistic trying to provide this consistency.

i bumped the version so we would need a tag for it to be available via the updater, im curious to see if it will work^^

i suggest that we use a release tag scheme where we can differ between the blender versions:
b28_v3.x.x
b27_v2.x.x