### PR TITLE
Bugfix/duplicationflag

### DIFF
--- a/GoB.py
+++ b/GoB.py
@@ -373,7 +373,7 @@ def apply_modifiers(obj, pref):
 
     # 1.create dummy object to apply ngon fix
     obj.select_set(state=True)
-    bpy.ops.object.duplicate(linked=False)
+    bpy.ops.object.duplicate()
     obj_temp = bpy.context.active_object
     obj_temp.select_set(state=True)
     obj.select_set(state=False)

--- a/__init__.py
+++ b/__init__.py
@@ -33,7 +33,7 @@ bl_info = {
     "name": "GoB",
     "description": "An unofficial GOZ-like addon for Blender",
     "author": "ODe, JoseConseco, kromar",
-    "version": (3, 0, 0),
+    "version": (3, 0, 2),
     "blender": (2, 80, 0),
     "location": "In the info header",
     "wiki_url": "http://wiki.blender.org/index.php/Extensions:"


### PR DESCRIPTION
had a bug report about the linked flag when duplicating a mesh, seems theres some changes in the api. since the flag is optional i removed it.