### PR TITLE
change report bug link to github issue tracker

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -38,8 +38,7 @@ bl_info = {
     "location": "In the info header",
     "wiki_url": "http://wiki.blender.org/index.php/Extensions:"
                 "2.6/Py/Scripts/Import-Export/GoB_ZBrush_import_export",
-    "tracker_url": "http://www.zbrushcentral.com/showthread.php?"
-                "127419-GoB-an-unofficial-GoZ-for-Blender",
+    "tracker_url": "https://github.com/JoseConseco/GoB/issues/new",
     "category": "Import-Export"}
 
 


### PR DESCRIPTION
i noticed that the report button in the addon takes us to the old zbrush forum, and since we work now with github i changed the link to the issue tracking here.
what do you think about this? would you rather have the link to the new zbrush forum?