### PR TITLE
Bugfix/udpater fixes

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -476,7 +476,7 @@ class addon_updater_updated_successful(bpy.types.Operator):
 				msg = updater.error_msg
 			else:
 				msg = self.error
-			col.label(str(msg), icon="BLANK1")
+			col.label(text=str(msg), icon="BLANK1")
 			rw = col.row()
 			rw.scale_y = 2
 			rw.operator("wm.url_open",
@@ -1358,7 +1358,7 @@ def register(bl_info):
 	# which enables pulling down release logs/notes, as well as specify installs from
 	# release-attached zips (instead of just the auto-packaged code generated with
 	# a release/tag). Setting has no impact on BitBucket or GitLab repos
-	updater.use_releases = True
+	updater.use_releases = False
 	# note: Releases always have a tag, but a tag may not always be a release
 	# Therefore, setting True above will filter out any non-annoted tags
 	# note 2: Using this option will also display the release name instead of

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -1358,7 +1358,7 @@ def register(bl_info):
 	# which enables pulling down release logs/notes, as well as specify installs from
 	# release-attached zips (instead of just the auto-packaged code generated with
 	# a release/tag). Setting has no impact on BitBucket or GitLab repos
-	updater.use_releases = False
+	updater.use_releases = True
 	# note: Releases always have a tag, but a tag may not always be a release
 	# Therefore, setting True above will filter out any non-annoted tags
 	# note 2: Using this option will also display the release name instead of


### PR DESCRIPTION
fixed a bug in the updater that produced a error.

also we need to change the tags to not confuse the updater, as you can see in the image the new version will always be bigger than the current one which always shows a update for users. so we need to remove any number that is not related to the version since the updater filters out all numbers from the tag and uses it as version. 
i already pushed new tags so only the old ones need to be removed.
![image](https://user-images.githubusercontent.com/1472884/57966963-3cc36780-7959-11e9-8be6-283efa4da30a.png)
