### PR TITLE
remove ZTL files to fix subtool mess in zbrush

### DIFF
--- a/GoB.py
+++ b/GoB.py
@@ -1094,6 +1094,13 @@ class GoB_OT_export(bpy.types.Operator):
         global cached_last_edition_time
         cached_last_edition_time = os.path.getmtime(f"{PATHGOZ}/GoZBrush/GoZ_ObjectList.txt")
         
+        # remove ZTL files since they mess up Zbrush importing subtools 
+        folder_path = f'{PATHGOZ}/GoZProjects/Default/'
+        for file_name in os.listdir(folder_path):
+            if file_name.endswith('.ZTL'):
+                os.remove(folder_path + file_name)
+                print('remove ztl file:', file_name)
+
         os.system(f"{PATHGOZ}/GoZBrush/{FROMAPP}")
         
         #if not os.path.isfile(f"{PATHGOZ}/GoZProjects/Default/{obj.name}.ZTL"):


### PR DESCRIPTION
zbrush would create a big mess when ZTL files of different sets of objects are present in the **C:\Users\Public\Pixologic\GoZProjects\Default** folder. to fix this i remove all ZTL files before sending objects over from blender to zbrush.
I do not see how else to avoid the mess since it looks like its the way how zbrush processes the content of files.