### PR TITLE
Remove autosave preferences

### DIFF
--- a/GoB.py
+++ b/GoB.py
@@ -1486,7 +1486,6 @@ class GoB_OT_GoZ_Installer_WIN(Operator):
         """Install GoZ for Windows"""  
         pref = context.preferences.addons[__package__].preferences 
         bpy.ops.gob.find_zbrush()
-        bpy.ops.wm.save_userpref()
                             
         if 'ZBrush.exe' in pref.zbrush_exec: 
             path = pref.zbrush_exec.strip("\ZBrush.exe")            

--- a/GoB.py
+++ b/GoB.py
@@ -1413,13 +1413,11 @@ class GoB_OT_export(Operator):
         if isMacOS: 
             if not 'ZBrush.app' in pref.zbrush_exec:                
                 bpy.ops.gob.find_zbrush()
-                bpy.ops.wm.save_userpref()            
             Popen(['open', '-a', pref.zbrush_exec, PATH_SCRIPT])        
         #windows
         else: 
             if not 'ZBrush.exe' in pref.zbrush_exec:              
                 bpy.ops.gob.find_zbrush() 
-                bpy.ops.wm.save_userpref()               
             Popen([pref.zbrush_exec, PATH_SCRIPT])         
 
         if context.object:


### PR DESCRIPTION
Preferences shouldn't be saved without the user's authorization. 
Maybe someone is playing around with settings, clicks this button as part of their tests, then come to find out all their settings were destroyed at some unknown point because of this. 