### PR TITLE
Fix export keybind always exporting as tool or subtool

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -47,6 +47,7 @@ bl_info = {
 classes = (
     GoB.GoB_OT_import,
     GoB.GoB_OT_export,
+    GoB.GoB_OT_export_button,
     GoB.GoB_OT_GoZ_Installer_WIN,
     GoB.GOB_OT_Popup,
     preferences.GoB_Preferences,


### PR DESCRIPTION
`scene.gob_export` uses the event's modifier keys to determine if it should export as tool or subtool.
While this works for the button, if you add a key binding like Ctrl-G it will always export as tool.

I split the button into its own operator so that functionality doesn't change and made `scene.gob_export` expose a property instead.
![bind](https://user-images.githubusercontent.com/59247540/111023246-d4683480-83cf-11eb-8088-ea3f3d2f1d43.png)
