### PR TITLE
Export raw object names

### DIFF
--- a/GoB.py
+++ b/GoB.py
@@ -1266,7 +1266,7 @@ def find_zbrush(self, context):
                 if 'zbrush.exe' in str.lower(prefs().zbrush_exec): 
                     self.is_found = True
 
-            elif os.path.isdir(prefs().zbrush_exec): #search for zbrush files in this folder and its subfodlers 
+            elif os.path.isdir(prefs().zbrush_exec): #search for zbrush files in this folder and its subfolders 
                 for folder in os.listdir(prefs().zbrush_exec): 
                     if "zbrush" in str.lower(folder):     #search for content inside folder that contains zbrush
                         #search subfolders for executables
@@ -1274,7 +1274,7 @@ def find_zbrush(self, context):
                             i,zfolder = max_list_value(os.listdir(os.path.join(prefs().zbrush_exec)))
                             for file in os.listdir(os.path.join(prefs().zbrush_exec, zfolder)):
                                 if ('zbrush.exe' in str.lower(file) in str.lower(file)):            
-                                    prefs().zbrush_exec = os.path.join(prefs().zbrush_exec, zfolder, f)           
+                                    prefs().zbrush_exec = os.path.join(prefs().zbrush_exec, zfolder, file)           
                                     self.is_found = True   
 
                         #find executable

--- a/GoB.py
+++ b/GoB.py
@@ -1225,16 +1225,18 @@ class GoB_OT_export(Operator):
         Keep only alphanumeric characters, underscore, dash and dot, and replace other characters with an underscore.
         Multiple consecutive invalid characters will be replaced with just a single underscore character.
         """
-        import re
-        new_name = re.sub('[^\w\_\-]+', '_', obj.name)
-        if new_name == obj.name:
-            return
-        i = 0
-        while new_name in bpy.data.objects.keys(): #while name collision with other scene objs,
-            name_cut = None if i == 0 else -2  #in first loop, do not slice name.
-            new_name = new_name[:name_cut] + str(i).zfill(2) #add two latters to end of obj name.
-            i += 1
-        obj.name = new_name
+        if prefs().export_raw_object_names:
+            import re
+            new_name = re.sub('[^\w\_\-]+', '_', obj.name)
+            if obj.name == obj.name:
+                return
+            i = 0
+            
+            while obj.name in bpy.data.objects.keys(): #while name collision with other scene objs,
+                name_cut = None if i == 0 else -2  #in first loop, do not slice name.
+                new_name = obj.name[:name_cut] + str(i).zfill(2) #add two latters to end of obj name.
+                i += 1
+            obj.name = new_name
 
        
 class GoB_OT_export_button(Operator):

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ bl_info = {
     "name": "GoB",
     "description": "An unofficial GOZ-like addon for Blender",
     "author": "ODe, JoseConseco, Daniel Grauer",
-    "version": (3, 5, 55),
+    "version": (3, 5, 56),
     "blender": (2, 83, 0),
     "location": "In the info header",
     "doc_url": "https://github.com/JoseConseco/GoB/wiki",                

--- a/preferences.py
+++ b/preferences.py
@@ -174,6 +174,11 @@ class GoB_Preferences(AddonPreferences):
         name="Delete non manifold faces",
         description="Delete non manifold faces",
         default=True)
+    
+    export_raw_object_names: BoolProperty(
+        name="export_raw_object_names",
+        description="export_raw_object_names",
+        default=True)
 
     export_merge: BoolProperty(
         name="Merge Vertices of Curves, Surfaces, Fonts and Meta Objects",

--- a/preferences.py
+++ b/preferences.py
@@ -176,9 +176,9 @@ class GoB_Preferences(AddonPreferences):
         default=True)
     
     export_raw_object_names: BoolProperty(
-        name="export_raw_object_names",
-        description="export_raw_object_names",
-        default=True)
+        name="[Experimental] Export Raw Object Names",
+        description="Object names will not be changed when exporting, this might cause some name changes in zbrush",
+        default=False)
 
     export_merge: BoolProperty(
         name="Merge Vertices of Curves, Surfaces, Fonts and Meta Objects",
@@ -362,6 +362,7 @@ class GoB_Preferences(AddonPreferences):
         if self.export_merge:
             col.prop(self, 'export_merge_distance') 
         col.prop(self, 'export_remove_internal_faces')
+        col.prop(self, 'export_raw_object_names')
         
         
         


### PR DESCRIPTION
added option to export the raw names since the renaming is not always desired. also it seems zbrush supports . in subtools so it should be possible to properly send such filenames over to zbrush.