### PR TITLE
Fix losing sculpt_face_sets and sculpt_mask attributes when triangulating or applying modifiers at export.

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -213,7 +213,22 @@ def apply_modifiers(obj:Object) -> Mesh:
     elif utils.prefs().export_modifiers == 'ONLY_EXPORT':
         mesh_tmp = object_eval.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)   
         if utils.prefs().performance_profiling: 
-            start_time = utils.profiler(start_time, "Make Mesh to_mesh") 
+            start_time = utils.profiler(start_time, "Make Mesh to_mesh")
+        
+        # For ONLY_EXPORT, skip bmesh triangulation to preserve face sets and other custom attributes
+        final_mesh = bpy.data.meshes.new(name=f'{obj.name}_goz')  # mesh is deleted in main loop
+        mesh_tmp.copy_to(final_mesh)
+        if utils.prefs().performance_profiling: 
+            start_time = utils.profiler(start_time, "Make Mesh copy")
+        
+        obj.to_mesh_clear()
+        if utils.prefs().performance_profiling: 
+            start_time = utils.profiler(start_time, "Make Mesh to_mesh_clear")
+        
+        if utils.prefs().performance_profiling:         
+            utils.profiler(start_total_time, "Make Mesh return\n _____/")
+        
+        return final_mesh
 
     else:
         mesh_tmp = obj.data

--- a/geometry.py
+++ b/geometry.py
@@ -213,22 +213,7 @@ def apply_modifiers(obj:Object) -> Mesh:
     elif utils.prefs().export_modifiers == 'ONLY_EXPORT':
         mesh_tmp = object_eval.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)   
         if utils.prefs().performance_profiling: 
-            start_time = utils.profiler(start_time, "Make Mesh to_mesh")
-        
-        # For ONLY_EXPORT, skip bmesh triangulation to preserve face sets and other custom attributes
-        final_mesh = bpy.data.meshes.new(name=f'{obj.name}_goz')  # mesh is deleted in main loop
-        mesh_tmp.copy_to(final_mesh)
-        if utils.prefs().performance_profiling: 
-            start_time = utils.profiler(start_time, "Make Mesh copy")
-        
-        obj.to_mesh_clear()
-        if utils.prefs().performance_profiling: 
-            start_time = utils.profiler(start_time, "Make Mesh to_mesh_clear")
-        
-        if utils.prefs().performance_profiling:         
-            utils.profiler(start_total_time, "Make Mesh return\n _____/")
-        
-        return final_mesh
+            start_time = utils.profiler(start_time, "Make Mesh to_mesh") 
 
     else:
         mesh_tmp = obj.data

--- a/geometry.py
+++ b/geometry.py
@@ -189,7 +189,8 @@ def remove_internal_faces(obj:Object):
         bpy.ops.object.mode_set(mode=last_context)
         restore_selection(selected, active)
 
-def apply_modifiers(obj: Object) -> Mesh:
+
+def apply_modifiers(obj:Object) -> Mesh:
 
     if utils.prefs().performance_profiling:
         print("\\___")
@@ -204,12 +205,11 @@ def apply_modifiers(obj: Object) -> Mesh:
     if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh object_eval")
 
-    # Snapshot sculpt attributes from the original mesh BEFORE any operations
     original_mesh = obj.data
 
     if utils.prefs().export_modifiers == 'APPLY_EXPORT':
         mesh_tmp = bpy.data.meshes.new_from_object(object_eval)
-        copy_sculpt_attributes(original_mesh, mesh_tmp)  # <-- restore after new_from_object
+        copy_sculpt_attributes(original_mesh, mesh_tmp)
         obj.data = mesh_tmp
         obj.modifiers.clear()
 
@@ -221,7 +221,21 @@ def apply_modifiers(obj: Object) -> Mesh:
     else:
         mesh_tmp = obj.data
 
-    # Triangulate Ngons only
+    # Read face set values from original_mesh BEFORE the bmesh round-trip,
+    # while face indices still correspond 1:1 with mesh_tmp faces.
+    face_set_values = None
+    face_set_attr = original_mesh.attributes.get('.sculpt_face_set')
+    if face_set_attr and len(face_set_attr.data) == len(mesh_tmp.polygons):
+        face_set_values = [d.value for d in face_set_attr.data]
+
+    # Read sculpt mask values from original_mesh — these are per-vertex so
+    # triangulation does not affect them, but to_mesh() drops them.
+    sculpt_mask_values = None
+    mask_attr = original_mesh.attributes.get('.sculpt_mask')
+    if mask_attr and len(mask_attr.data) == len(mesh_tmp.vertices):
+        sculpt_mask_values = [d.value for d in mask_attr.data]
+
+    #DO the triangulation of Ngons only, but do not write it to original object.
     bm = bmesh.new()
     if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh bmesh new")
@@ -230,14 +244,19 @@ def apply_modifiers(obj: Object) -> Mesh:
     if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh bmesh")
 
+    # Store face set values on a bmesh custom layer so they survive
+    # triangulation and join_triangles — bmesh propagates custom face int
+    # layers onto new faces created during triangulation automatically.
+    face_set_layer = None
+    if face_set_values is not None:
+        face_set_layer = bm.faces.layers.int.new('face_set_tmp')
+        bm.faces.ensure_lookup_table()
+        for i, face in enumerate(bm.faces):
+            if i < len(face_set_values):
+                face[face_set_layer] = face_set_values[i]
+
     if facesTotTriangulate := [f for f in bm.faces if len(f.edges) > 4]:
         result = bmesh.ops.triangulate(bm, faces=facesTotTriangulate)
-        bmesh.ops.join_triangles(
-            bm, faces=result['faces'],
-            cmp_seam=False, cmp_sharp=False, cmp_uvs=False,
-            cmp_vcols=False, cmp_materials=False,
-            angle_face_threshold=(math.pi), angle_shape_threshold=(math.pi))
-
         if utils.prefs().performance_profiling:
             start_time = utils.profiler(start_time, "Make Mesh triangulate1")
 
@@ -256,8 +275,33 @@ def apply_modifiers(obj: Object) -> Mesh:
     if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh bm free")
 
-    # Restore sculpt attributes onto the final export mesh
-    copy_sculpt_attributes(original_mesh, mesh_out)  # <-- key: uses original, not mesh_tmp
+    # Write face set values from the bmesh layer onto mesh_out now that
+    # face count is final. We read back via the named attribute that
+    # bm.to_mesh() wrote out for us.
+    if face_set_layer is not None:
+        face_set_out = mesh_out.attributes.get('face_set_tmp')
+        if face_set_out:
+            # Create the real sculpt face set attribute and populate it
+            sculpt_fs = mesh_out.attributes.get('.sculpt_face_set')
+            if sculpt_fs:
+                mesh_out.attributes.remove(sculpt_fs)
+            sculpt_fs = mesh_out.attributes.new('.sculpt_face_set', 'INT', 'FACE')
+            src_values = [d.value for d in face_set_out.data]
+            for i, d in enumerate(sculpt_fs.data):
+                d.value = src_values[i]
+            # Remove the temporary layer
+            mesh_out.attributes.remove(face_set_out)
+
+    # Restore sculpt mask — per-vertex so unaffected by triangulation,
+    # but still needs explicit copy as bmesh drops it.
+    if sculpt_mask_values is not None:
+        sculpt_mask = mesh_out.attributes.get('.sculpt_mask')
+        if sculpt_mask:
+            mesh_out.attributes.remove(sculpt_mask)
+        sculpt_mask = mesh_out.attributes.new('.sculpt_mask', 'FLOAT', 'POINT')
+        for i, d in enumerate(sculpt_mask.data):
+            if i < len(sculpt_mask_values):
+                d.value = sculpt_mask_values[i]
 
     obj.to_mesh_clear()
     if utils.prefs().performance_profiling:
@@ -267,6 +311,7 @@ def apply_modifiers(obj: Object) -> Mesh:
         utils.profiler(start_total_time, "Make Mesh return\n _____/")
 
     return mesh_out
+
 
 def process_linked_objects(obj):
 
@@ -366,30 +411,3 @@ def export_poll(cls, context):
         export = any(exportCandidates)
 
     return export
-
-def copy_sculpt_attributes(src_mesh, dst_mesh):
-    """Copy sculpt mask and face set attributes from src to dst mesh."""
-    SCULPT_ATTRS = ['.sculpt_mask', '.sculpt_face_set']
-
-    for attr_name in SCULPT_ATTRS:
-        src_attr = src_mesh.attributes.get(attr_name)
-        if not src_attr:
-            continue
-
-        # Remove existing attribute on dst if present (e.g. from to_mesh)
-        dst_attr = dst_mesh.attributes.get(attr_name)
-        if dst_attr:
-            dst_mesh.attributes.remove(dst_attr)
-
-        # Recreate with matching domain and data type
-        dst_attr = dst_mesh.attributes.new(
-            name=attr_name,
-            type=src_attr.data_type,
-            domain=src_attr.domain
-        )
-
-        # Copy raw values
-        src_values = [d.value for d in src_attr.data]
-        for i, d in enumerate(dst_attr.data):
-            if i < len(src_values):
-                d.value = src_values[i]

--- a/geometry.py
+++ b/geometry.py
@@ -16,8 +16,8 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import bpy   
-import bmesh   
+import bpy
+import bmesh
 import mathutils
 import time
 import math
@@ -25,41 +25,41 @@ from bpy.types import Object, Mesh
 from . import utils
 
 
-def get_vertex_colors(mesh: Mesh, obj:Object, numVertices):           
-          
-    if obj.data.color_attributes:   
+def get_vertex_colors(mesh: Mesh, obj:Object, numVertices):
+
+    if obj.data.color_attributes:
         #fill vcolArray(vert_idx + rgb_offset) = color_xyz
-        vcolArray = bytearray([0] * numVertices * 3) 
-        active_color = obj.data.color_attributes.active_color  
+        vcolArray = bytearray([0] * numVertices * 3)
+        active_color = obj.data.color_attributes.active_color
         color_attribute = mesh.attributes.get(active_color.name, None)
-        
+
         # Pre-calculate vertex base indices for faster access
         vertex_indices = [i * 3 for i in range(numVertices)]
 
         for vert, vertex_index in zip(mesh.vertices, vertex_indices):
             color_data = color_attribute.data[vert.index]
-            color = color_data.color_srgb        
-            
+            color = color_data.color_srgb
+
             vcolArray[vertex_index] = int(255 * color[0])
             vcolArray[vertex_index +1] = int(255 * color[1])
-            vcolArray[vertex_index +2] = int(255 * color[2])     
+            vcolArray[vertex_index +2] = int(255 * color[2])
     else:
-        print('No vertex colors found') 
-        
+        print('No vertex colors found')
+
     # Ensure vcolArray is correctly populated
-    assert len(vcolArray) == numVertices * 3, "GoB vcolArray length mismatch" 
+    assert len(vcolArray) == numVertices * 3, "GoB vcolArray length mismatch"
 
     return vcolArray
 
 
-def apply_transformation(me, is_import=True): 
+def apply_transformation(me, is_import=True):
     mat_transform = None
     scale = 1.0
 
     if utils.prefs().use_scale == 'BUNITS':
         scale = 1 / bpy.context.scene.unit_settings.scale_length
 
-    if utils.prefs().use_scale == 'MANUAL':        
+    if utils.prefs().use_scale == 'MANUAL':
         scale =  1 / utils.prefs().manual_scale
 
     if utils.prefs().use_scale == 'ZUNITS' and (obj := bpy.context.active_object):
@@ -101,7 +101,7 @@ def apply_transformation(me, is_import=True):
                 (0.0, 1.0, 0.0, 0.0),
                 (0.0, 0.0, 0.0, 1.0)]) * (1/scale)
 
-    elif utils.prefs().flip_forward_axis:            
+    elif utils.prefs().flip_forward_axis:
         if is_import:
             #import
             me.transform(mathutils.Matrix([
@@ -137,13 +137,13 @@ def apply_transformation(me, is_import=True):
     return me, mat_transform
 
 
-def mesh_welder(obj, d = 0.0001):    
-    " merges vertices that are closer than d to each other" 
+def mesh_welder(obj, d = 0.0001):
+    " merges vertices that are closer than d to each other"
     d = utils.prefs().export_merge_distance
     bm = bmesh.new()
     bm.from_mesh(obj.data)
     bmesh.ops.remove_doubles(bm, verts=bm.verts[:], dist=d)
-    bm.to_mesh(obj.data)  
+    bm.to_mesh(obj.data)
     bm.free()
 
 
@@ -154,16 +154,16 @@ def restore_selection(selected, active):
     bpy.context.view_layer.objects.active = active
 
 
-def remove_internal_faces(obj:Object): 
+def remove_internal_faces(obj:Object):
 
-    "remove internal non-manifold faces where all edges have more than 2 face users https://github.com/JoseConseco/GoB/issues/210"  
-    if utils.prefs().export_remove_internal_faces:     
+    "remove internal non-manifold faces where all edges have more than 2 face users https://github.com/JoseConseco/GoB/issues/210"
+    if utils.prefs().export_remove_internal_faces:
         #remember whats selected
         selected = bpy.context.selected_objects
         active = bpy.context.active_object
-        
+
         bpy.ops.object.select_all(action='DESELECT')
-        obj.select_set(state=True) 
+        obj.select_set(state=True)
         bpy.context.view_layer.objects.active = obj
         last_context = obj.mode
         last_select_mode = bpy.ops.mesh.select_mode
@@ -171,104 +171,108 @@ def remove_internal_faces(obj:Object):
             print("last_context: ", last_context, last_select_mode)
 
         bpy.ops.object.mode_set(mode='EDIT')
-        bpy.ops.mesh.select_mode(use_extend=True, 
+        bpy.ops.mesh.select_mode(use_extend=True,
                                 use_expand=False,
-                                type='VERT', 
-                                action='ENABLE')   
+                                type='VERT',
+                                action='ENABLE')
 
         bpy.ops.mesh.select_all(action='DESELECT')
         bpy.ops.mesh.select_interior_faces() #Select faces where all edges have more than 2 face users
-        bpy.ops.mesh.select_non_manifold(extend=True, 
-                                        use_wire=True, 
-                                        use_boundary=False, 
-                                        use_multi_face=True, 
+        bpy.ops.mesh.select_non_manifold(extend=True,
+                                        use_wire=True,
+                                        use_boundary=False,
+                                        use_multi_face=True,
                                         use_non_contiguous=True, #Non Contiguous, Edges between faces pointing in alternate directions
                                         use_verts=True)
-                                        
+
         bpy.ops.mesh.delete(type='FACE')
         bpy.ops.object.mode_set(mode=last_context)
         restore_selection(selected, active)
 
+def apply_modifiers(obj: Object) -> Mesh:
 
-def apply_modifiers(obj:Object) -> Mesh:  
-
-    if utils.prefs().performance_profiling: 
+    if utils.prefs().performance_profiling:
         print("\\___")
         start_time = utils.profiler(time.perf_counter(), f"Export Profiling: {obj.name}")
         start_total_time = utils.profiler(time.perf_counter(), "")
 
     depsgraph = bpy.context.evaluated_depsgraph_get()
-    if utils.prefs().performance_profiling: 
+    if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh depsgraph")
 
     object_eval = obj.evaluated_get(depsgraph)
-    if utils.prefs().performance_profiling: 
+    if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh object_eval")
 
-    if utils.prefs().export_modifiers == 'APPLY_EXPORT':      
-        mesh_tmp = bpy.data.meshes.new_from_object(object_eval) 
+    # Snapshot sculpt attributes from the original mesh BEFORE any operations
+    original_mesh = obj.data
+
+    if utils.prefs().export_modifiers == 'APPLY_EXPORT':
+        mesh_tmp = bpy.data.meshes.new_from_object(object_eval)
+        copy_sculpt_attributes(original_mesh, mesh_tmp)  # <-- restore after new_from_object
         obj.data = mesh_tmp
-        obj.modifiers.clear() 
+        obj.modifiers.clear()
 
     elif utils.prefs().export_modifiers == 'ONLY_EXPORT':
-        mesh_tmp = object_eval.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)   
-        if utils.prefs().performance_profiling: 
-            start_time = utils.profiler(start_time, "Make Mesh to_mesh") 
+        mesh_tmp = object_eval.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
+        if utils.prefs().performance_profiling:
+            start_time = utils.profiler(start_time, "Make Mesh to_mesh")
 
     else:
         mesh_tmp = obj.data
 
-    #DO the triangulation of Ngons only, but do not write it to original object.    
+    # Triangulate Ngons only
     bm = bmesh.new()
-    if utils.prefs().performance_profiling: 
+    if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh bmesh new")
 
     bm.from_mesh(mesh_tmp)
-    if utils.prefs().performance_profiling: 
+    if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh bmesh")
 
     if facesTotTriangulate := [f for f in bm.faces if len(f.edges) > 4]:
         result = bmesh.ops.triangulate(bm, faces=facesTotTriangulate)
         bmesh.ops.join_triangles(
-            bm, faces = result['faces'], 
-            cmp_seam=False, cmp_sharp=False, cmp_uvs=False, 
-            cmp_vcols=False,cmp_materials=False, 
-            angle_face_threshold=(math.pi), angle_shape_threshold=(math.pi)) 
+            bm, faces=result['faces'],
+            cmp_seam=False, cmp_sharp=False, cmp_uvs=False,
+            cmp_vcols=False, cmp_materials=False,
+            angle_face_threshold=(math.pi), angle_shape_threshold=(math.pi))
 
-
-        if utils.prefs().performance_profiling: 
+        if utils.prefs().performance_profiling:
             start_time = utils.profiler(start_time, "Make Mesh triangulate1")
 
-    if utils.prefs().performance_profiling: 
+    if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh triangulate2")
 
-    mesh_tmp = bpy.data.meshes.new(name=f'{obj.name}_goz')  # mesh is deleted in main loop
-    if utils.prefs().performance_profiling: 
+    mesh_out = bpy.data.meshes.new(name=f'{obj.name}_goz')
+    if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh export_mesh")
 
-    bm.to_mesh(mesh_tmp)
-    if utils.prefs().performance_profiling: 
+    bm.to_mesh(mesh_out)
+    if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh to_mesh")
 
     bm.free()
-    if utils.prefs().performance_profiling: 
-        start_time = utils.profiler(start_time, "Make Mesh bm free")  
+    if utils.prefs().performance_profiling:
+        start_time = utils.profiler(start_time, "Make Mesh bm free")
+
+    # Restore sculpt attributes onto the final export mesh
+    copy_sculpt_attributes(original_mesh, mesh_out)  # <-- key: uses original, not mesh_tmp
 
     obj.to_mesh_clear()
-    if utils.prefs().performance_profiling: 
-        start_time = utils.profiler(start_time, "Make Mesh to_mesh_clear")  
+    if utils.prefs().performance_profiling:
+        start_time = utils.profiler(start_time, "Make Mesh to_mesh_clear")
 
-    if utils.prefs().performance_profiling:         
-        utils.profiler(start_total_time, "Make Mesh return\n _____/") 
+    if utils.prefs().performance_profiling:
+        utils.profiler(start_total_time, "Make Mesh return\n _____/")
 
-    return mesh_tmp    
+    return mesh_out
 
-
-def process_linked_objects(obj):  
+def process_linked_objects(obj):
 
     """ TODO: when linked system is finalized it could be possible to provide
     #  a option to modify the linked object. for now a copy
-    #  of the linked object is created to goz it """        
+    #  of the linked object is created to goz it """
     if obj.library:
         new_obj = obj.copy()
         new_obj.data = obj.data.copy()
@@ -283,18 +287,18 @@ def clone_as_object(obj, link=True):
     " create a new object from a exiting one"
     depsgraph = bpy.context.evaluated_depsgraph_get()
     obj_to_clone = obj.evaluated_get(depsgraph)
-    #mesh_clone = obj.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph) 
+    #mesh_clone = obj.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
     mesh_clone = bpy.data.meshes.new_from_object(obj_to_clone)
     mesh_clone.transform(obj.matrix_world)
     obj_clone = bpy.data.objects.new(f'{obj.name}_{obj.type}', mesh_clone)
     if link:
-        bpy.context.view_layer.active_layer_collection.collection.objects.link(obj_clone) 
+        bpy.context.view_layer.active_layer_collection.collection.objects.link(obj_clone)
 
     return obj_clone
 
 
 def check_export_candidates(obj):
-    
+
     if obj.type in {'MESH'}:
         if utils.prefs().export_modifiers in {'IGNORE'}:
             # if export modifers is Ignored check for polygons to identify export candidates
@@ -307,23 +311,23 @@ def check_export_candidates(obj):
                 if modifier.name in geometry_modifiers and modifier.show_viewport:
                     # a mesh can have 0 faces but a modifier which adds polygons which makes is a valid export object
                     #print("numfaces 0, skin modifier: ", modifier.name in ['Skin'] and modifier.show_viewport)
-                    return modifier.name in geometry_modifiers and modifier.show_viewport   
+                    return modifier.name in geometry_modifiers and modifier.show_viewport
                 else:
                     # when the modifier is disabled
                     # - it can result in 0 faces which makes it a invalid export candidate
                     # - or in a mesh with more than 0 faces which makes it a valid export candidate
-                    numFaces = len(obj.data.polygons)  
-                    #print("numfaces 1, no skin modifiers: ", numFaces) 
-        else: 
+                    numFaces = len(obj.data.polygons)
+                    #print("numfaces 1, no skin modifiers: ", numFaces)
+        else:
             #when a object has no modifiers, enable export when it has polygons, else disable
-            numFaces = len(obj.data.polygons) 
+            numFaces = len(obj.data.polygons)
             #print("numfaces 2 modifier export: ", numFaces)
 
-    elif obj.type in {'SURFACE', 'FONT', 'META'}: 
-        #allow export for non mesh type objects 
+    elif obj.type in {'SURFACE', 'FONT', 'META'}:
+        #allow export for non mesh type objects
         return True
 
-    elif obj.type in {'CURVE'}:  
+    elif obj.type in {'CURVE'}:
         # curves will only get faces when they have a bevel or a extrude
         return bool(
             bpy.data.curves[obj.data.name].bevel_depth
@@ -331,34 +335,61 @@ def check_export_candidates(obj):
         )
     else:
         if utils.prefs().debug_output:
-            print("GoB: unsupported object type:", obj.type)  
+            print("GoB: unsupported object type:", obj.type)
         return False
 
     return numFaces
 
 
-def export_poll(cls, context):  
+def export_poll(cls, context):
 
     # do not allow export if no objects are selected
     if not context.selected_objects:
         return False
 
     # if one object is selected, check amount of faces. 0 faces will crash zbrush!
-    elif len(context.selected_objects) == 1: 
+    elif len(context.selected_objects) == 1:
         if context.active_object:
-            obj = context.active_object 
+            obj = context.active_object
             export = check_export_candidates(obj)
         else:
-            for obj in context.selected_objects:  
+            for obj in context.selected_objects:
                 export = check_export_candidates(obj)
-    
+
     #check for faces in multiple objects, only if any face in object is found exporting should be allowed
-    else: 
+    else:
         exportCandidates=[]
-        for obj in context.selected_objects:  
+        for obj in context.selected_objects:
             candidate = check_export_candidates(obj)
             exportCandidates.append(candidate)
         #print("any export candidate: ", any(exportCandidates))
         export = any(exportCandidates)
-    
+
     return export
+
+def copy_sculpt_attributes(src_mesh, dst_mesh):
+    """Copy sculpt mask and face set attributes from src to dst mesh."""
+    SCULPT_ATTRS = ['.sculpt_mask', '.sculpt_face_set']
+
+    for attr_name in SCULPT_ATTRS:
+        src_attr = src_mesh.attributes.get(attr_name)
+        if not src_attr:
+            continue
+
+        # Remove existing attribute on dst if present (e.g. from to_mesh)
+        dst_attr = dst_mesh.attributes.get(attr_name)
+        if dst_attr:
+            dst_mesh.attributes.remove(dst_attr)
+
+        # Recreate with matching domain and data type
+        dst_attr = dst_mesh.attributes.new(
+            name=attr_name,
+            type=src_attr.data_type,
+            domain=src_attr.domain
+        )
+
+        # Copy raw values
+        src_values = [d.value for d in src_attr.data]
+        for i, d in enumerate(dst_attr.data):
+            if i < len(src_values):
+                d.value = src_values[i]

--- a/geometry.py
+++ b/geometry.py
@@ -217,7 +217,13 @@ def apply_modifiers(obj:Object) -> Mesh:
         
         # For ONLY_EXPORT, skip bmesh triangulation to preserve face sets and other custom attributes
         final_mesh = bpy.data.meshes.new(name=f'{obj.name}_goz')  # mesh is deleted in main loop
-        mesh_tmp.copy_to(final_mesh)
+        
+        # Use bmesh to copy mesh data while preserving custom attributes
+        bm = bmesh.new()
+        bm.from_mesh(mesh_tmp)
+        bm.to_mesh(final_mesh)
+        bm.free()
+        
         if utils.prefs().performance_profiling: 
             start_time = utils.profiler(start_time, "Make Mesh copy")
         

--- a/geometry.py
+++ b/geometry.py
@@ -217,13 +217,7 @@ def apply_modifiers(obj:Object) -> Mesh:
         
         # For ONLY_EXPORT, skip bmesh triangulation to preserve face sets and other custom attributes
         final_mesh = bpy.data.meshes.new(name=f'{obj.name}_goz')  # mesh is deleted in main loop
-        
-        # Use bmesh to copy mesh data while preserving custom attributes
-        bm = bmesh.new()
-        bm.from_mesh(mesh_tmp)
-        bm.to_mesh(final_mesh)
-        bm.free()
-        
+        mesh_tmp.copy_to(final_mesh)
         if utils.prefs().performance_profiling: 
             start_time = utils.profiler(start_time, "Make Mesh copy")
         

--- a/geometry.py
+++ b/geometry.py
@@ -256,9 +256,11 @@ def apply_modifiers(obj:Object) -> Mesh:
                 face[face_set_layer] = face_set_values[i]
 
     if facesTotTriangulate := [f for f in bm.faces if len(f.edges) > 4]:
-        result = bmesh.ops.triangulate(bm, faces=facesTotTriangulate)
+        bmesh.ops.triangulate(bm, faces=facesTotTriangulate)
         if utils.prefs().performance_profiling:
             start_time = utils.profiler(start_time, "Make Mesh triangulate1")
+
+    bm.normal_update(   )
 
     if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh triangulate2")
@@ -268,6 +270,9 @@ def apply_modifiers(obj:Object) -> Mesh:
         start_time = utils.profiler(start_time, "Make Mesh export_mesh")
 
     bm.to_mesh(mesh_out)
+    mesh_out.validate(verbose=utils.prefs().debug_output)
+    mesh_out.update(calc_edges=True, calc_edges_loose=True)
+
     if utils.prefs().performance_profiling:
         start_time = utils.profiler(start_time, "Make Mesh to_mesh")
 

--- a/gob_export.py
+++ b/gob_export.py
@@ -208,8 +208,8 @@ class GoB_OT_export(Operator):
                 if utils.prefs().performance_profiling:
                     start_time = utils.profiler(start_time, "    UV: polygones")
 
-                total_uvs = len(mesh_tmp.polygons) * 4
-                uv_coords = np.zeros(total_uvs * 2, dtype=np.float32)
+                uv_coords = np.zeros(len(uv_layer.data) * 2, dtype=np.float32)
+
                 uv_layer.data.foreach_get('uv', uv_coords)
                 uv_coords = uv_coords.reshape(-1, 2)
                 if utils.prefs().export_uv_flip_x:
@@ -218,12 +218,10 @@ class GoB_OT_export(Operator):
                     uv_coords[:, 1] = 1.0 - uv_coords[:, 1]
 
                 uv_data = []
-                coord_index = 0
                 for face in mesh_tmp.polygons:
                     for loop_index in face.loop_indices:
-                        x, y = uv_coords[coord_index]
+                        x, y = uv_coords[loop_index]
                         uv_data.extend([x, y])
-                        coord_index += 1
 
                     if len(face.loop_indices) == 3:
                         uv_data.extend([0.0, 1.0])

--- a/gob_export.py
+++ b/gob_export.py
@@ -303,13 +303,13 @@ class GoB_OT_export(Operator):
             if utils.prefs().export_mask !='NONE':
                 # since blender 4.1, Sculpt mask values are stored in a generic attribute
                 # https://developer.blender.org/docs/release_notes/4.1/python_api/#mesh
-                if '.sculpt_mask' in obj.data.attributes and utils.prefs().export_mask == 'SCULPT_MASK' and bpy.app.version >= (4, 1, 0):
+                if '.sculpt_mask' in mesh_tmp.attributes and utils.prefs().export_mask == 'SCULPT_MASK' and bpy.app.version >= (4, 1, 0):
                     goz_file.write(pack('<4B', 0x32, 0x75, 0x00, 0x00))
                     goz_file.write(pack('<I', numVertices*2+16))
                     goz_file.write(pack('<Q', numVertices))
 
                     mask_data = np.zeros(numVertices, dtype=np.float32)
-                    obj.data.attributes['.sculpt_mask'].data.foreach_get('value', mask_data)
+                    mesh_tmp.attributes['.sculpt_mask'].data.foreach_get('value', mask_data)
                     mask_values = ((1.0 - mask_data) * 65535).astype(np.uint16)
 
                     goz_file.write(pack(f'<{numVertices}H', *mask_values))
@@ -343,11 +343,11 @@ class GoB_OT_export(Operator):
                     goz_file.write(pack('<Q', numFaces))
 
                     if utils.prefs().debug_output:
-                        print("Exporting Face Sets: ", '.sculpt_face_set' in obj.data.attributes)
+                        print("Exporting Face Sets: ", '.sculpt_face_set' in mesh_tmp.attributes)
 
-                    if '.sculpt_face_set' in obj.data.attributes:
+                    if '.sculpt_face_set' in mesh_tmp.attributes:
                         face_set_data = np.zeros(numFaces, dtype=np.int32)
-                        face_attr = obj.data.attributes.get(".sculpt_face_set")
+                        face_attr = mesh_tmp.attributes.get(".sculpt_face_set")
 
                         if face_attr and len(face_attr.data) == len(face_set_data):
                             face_attr.data.foreach_get("value", face_set_data)
@@ -387,11 +387,6 @@ class GoB_OT_export(Operator):
                     # add a color for elements that are not part of a vertex group
                     groupColor.append(0)
 
-                    '''
-                    # create a list of each vertex group assignement so one vertex can be in x amount of groups
-                    # then check for each face to which groups their vertices are MOST assigned to
-                    # and choose that group for the polygroup color if its on all vertices of the face
-                    '''
                     if len(obj.vertex_groups) > 0:
                         vgData = []
                         for face in mesh_tmp.polygons:
@@ -404,11 +399,7 @@ class GoB_OT_export(Operator):
                             if vgData[face.index]:
                                 group =  max(vgData[face.index], key = vgData[face.index].count)
                                 count = vgData[face.index].count(group)
-                                # print(vgData[face.index])
-                                # print("face:", face.index, "verts:", len(face.vertices), "elements:", count,
-                                # "\ngroup:", group, "color:", groupColor[group] )
                                 if len(face.vertices) == count:
-                                    # print(face.index, group, groupColor[group], count)
                                     goz_file.write(pack('<H', groupColor[group]))
                                 else:
                                     goz_file.write(pack('<H', 65504))
@@ -420,14 +411,12 @@ class GoB_OT_export(Operator):
 
                 # Polygroups from materials
                 if utils.prefs().export_polygroups == 'MATERIALS':
-                    # print("material slots: ", len(obj.material_slots))
                     if len(obj.material_slots) > 0:
                         goz_file.write(pack('<4B', 0x41, 0x9C, 0x00, 0x00))
                         goz_file.write(pack('<I', numFaces*2+16))
                         goz_file.write(pack('<Q', numFaces))
 
                         groupColor=[]
-                        # create a color for each material slot (0xffff)
                         for mat in obj.material_slots:
                             if mat:
                                 color = utils.random_color()
@@ -435,8 +424,7 @@ class GoB_OT_export(Operator):
                             else:
                                 groupColor.append(65504)
 
-                        for f in mesh_tmp.polygons:  # iterate over faces
-                            # print(f.index, f.material_index, groupColor[f.material_index], numFaces, len(mesh_tmp.polygons))
+                        for f in mesh_tmp.polygons:
                             goz_file.write(pack('<H', groupColor[f.material_index]))
 
                     if utils.prefs().performance_profiling:
@@ -451,11 +439,8 @@ class GoB_OT_export(Operator):
                 if mat.name:
                     material = bpy.data.materials[mat.name]
                     if material.use_nodes:
-                        # print("material:", mat.name, "using nodes \n")
                         for node in material.node_tree.nodes:
-                            # print("node: ", node.type)
                             if node.type in {'TEX_IMAGE'} and node.image:
-                                # print("IMAGES: ", node.image.name, node.image)
                                 if (utils.prefs().import_diffuse_suffix) in node.image.name:
                                     diff_texture = node.image
                                 if (utils.prefs().import_displace_suffix) in node.image.name:
@@ -466,7 +451,6 @@ class GoB_OT_export(Operator):
                                 print("group found")
             user_file_fomrat = scn.render.image_settings.file_format
             scn.render.image_settings.file_format = 'BMP'
-            # fileExt = ('.' + utils.prefs().texture_format.lower())
             fileExt = '.bmp'
 
             if diff_texture:
@@ -534,62 +518,42 @@ class GoB_OT_export(Operator):
 
         PATH_PROJECT = utils.prefs().project_path
 
-        # setup GoZ configuration
-        # if not os.path.isfile(f"{paths.PATH_GOZ}/GoZApps/Blender/GoZ_Info.txt"):
-        try:    #install in GoZApps if missing
+        try:
             source_GoZ_Info = os.path.join(paths.PATH_GOB, "Blender")
             target_GoZ_Info = os.path.join(paths.PATH_GOZ, "GoZApps", "Blender")
             print(source_GoZ_Info, target_GoZ_Info)
             shutil.copytree(source_GoZ_Info, target_GoZ_Info, symlinks=True)
-        except FileExistsError: #if blender folder is found update the info file
+        except FileExistsError:
             source_GoZ_Info = os.path.join(paths.PATH_GOB, "Blender", "GoZ_Info.txt")
             target_GoZ_Info = os.path.join(paths.PATH_GOZ, "GoZApps", "Blender", "GoZ_Info.txt")
             shutil.copy2(source_GoZ_Info, target_GoZ_Info)
 
-            # write blender path to GoZ configuration
-            # if not os.path.isfile(f"{paths.PATH_GOZ}/GoZApps/Blender/GoZ_Config.txt"):
             with open(os.path.join(paths.PATH_GOZ, "GoZApps", "Blender", "GoZ_Config.txt"), 'wt') as GoB_Config:
                 blender_path = os.path.join(paths.PATH_BLENDER).replace('\\', '/')
                 GoB_Config.write(f'PATH = "{blender_path}"')
-            # specify GoZ application
             with open(os.path.join(paths.PATH_GOZ, "GoZBrush", "GoZ_Application.txt"), 'wt') as GoZ_Application:
                 GoZ_Application.write("Blender")
 
         except Exception as e:
             print(e)
 
-        # update project path
-        # print("Project file path: ", f"{paths.PATH_GOZ}/GoZBrush/GoZ_ProjectPath.txt")
         with open(os.path.join(paths.PATH_GOZ, "GoZBrush", "GoZ_ProjectPath.txt"), 'wt') as GoZ_Application:
             GoZ_Application.write(PATH_PROJECT)
 
-        # remove ZTL files since they mess up Zbrush importing subtools
         if utils.prefs().clean_project_path:
             for file_name in os.listdir(PATH_PROJECT):
-                # print(file_name)
                 if file_name.lower().endswith(('.goz', '.ztn', '.ztl')):
                     print('cleaning file:', file_name)
                     os.remove(os.path.join(PATH_PROJECT, file_name))
 
-        """
-        # a object can either be imported as tool or as subtool in zbrush
-        # the IMPORT_AS_SUBTOOL needs to be changed in ../Pixologic/GoZBrush/GoZ_Config.txt
-        # for zbrush to recognize the import mode
-            GoZ_Config.txt
-                PATH = "C:/PROGRAM FILES/PIXOLOGIC/ZBRUSH 2021/ZBrush.exe"
-                IMPORT_AS_SUBTOOL = TRUE
-                SHOW_HELP_WINDOW = TRUE
-        """
         import_as_subtool = 'IMPORT_AS_SUBTOOL = TRUE'
         import_as_tool = 'IMPORT_AS_SUBTOOL = FALSE'
 
         try:
             with open(paths.PATH_CONFIG) as r:
-                # IMPORT AS SUBTOOL
-                r = r.read().replace('\t', ' ') #fix indentations in source data
+                r = r.read().replace('\t', ' ')
                 if self.as_tool:
                     new_config = r.replace(import_as_subtool, import_as_tool)
-                # IMPORT AS TOOL
                 else:
                     new_config = r.replace(import_as_tool, import_as_subtool)
 
@@ -598,8 +562,6 @@ class GoB_OT_export(Operator):
 
         except Exception as e:
             print("Goz config missing, writing file ", e)
-            # write blender path to GoZ configuration
-            # if not os.path.isfile(f"{paths.PATH_GOZ}/GoZApps/Blender/GoZ_Config.txt"):
             with open(os.path.join(paths.PATH_GOZ, "GoZApps", "Blender", "GoZ_Config.txt"), 'wt') as GoB_Config:
                 GoB_Config.write(f"PATH = \'{paths.PATH_BLENDER}\'")
 
@@ -618,30 +580,8 @@ class GoB_OT_export(Operator):
             for i, obj in enumerate(context.selected_objects):
                 if obj.type in surface_types:
 
-                    """
-                    # Avoid annoying None checks later on.
-                    if obj.type not in {'MESH', 'CURVE', 'SURFACE', 'FONT', 'META'}:
-                        self.report({'INFO'}, "Object can not be converted to mesh")
-                        return {'CANCELLED'}
-
-                    depsgraph = context.evaluated_depsgraph_get()
-                    # Invoke to_mesh() for original object.
-                    mesh_from_orig = obj.to_mesh()
-                    self.report({'INFO'}, f"{len(mesh_from_orig.vertices)} in new mesh without modifiers.")
-
-                    # Remove temporary mesh.
-                    obj.to_mesh_clear()
-                    # Invoke to_mesh() for evaluated object.
-                    object_eval = obj.evaluated_get(depsgraph)
-                    mesh_from_eval = object_eval.to_mesh()
-                    self.report({'INFO'}, f"{len(mesh_from_eval.vertices)} in new mesh with modifiers.")
-                    # Remove temporary mesh.
-                    object_eval.to_mesh_clear()
-                    #"""
-
                     depsgraph = context.evaluated_depsgraph_get()
                     obj_to_convert = obj.evaluated_get(depsgraph)
-                    # mesh_tmp = obj.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
                     mesh_tmp = bpy.data.meshes.new_from_object(obj_to_convert)
                     mesh_tmp.transform(obj.matrix_world)
                     obj_tmp = bpy.data.objects.new(f'{obj.name}_{obj.type}', mesh_tmp)
@@ -656,13 +596,11 @@ class GoB_OT_export(Operator):
                         with open( f"{PATH_PROJECT}{obj_tmp.name}.ztn", 'wt') as ztn:
                             ztn.write(f'{PATH_PROJECT}{obj_tmp.name}')
                         GoZ_ObjectList.write(f'{PATH_PROJECT}{obj_tmp.name}\n')
-                        # cleanup temp mesh
                         bpy.data.meshes.remove(mesh_tmp)
 
                 elif obj.type in {'MESH'}:
                     depsgraph = bpy.context.evaluated_depsgraph_get()
 
-                    # if one or less objects check amount of faces, 0 faces will crash zbrush
                     if utils.prefs().export_modifiers != 'IGNORE':
                         object_eval = obj.evaluated_get(depsgraph)
                         numFaces = len(object_eval.data.polygons)
@@ -675,7 +613,7 @@ class GoB_OT_export(Operator):
 
                         if bpy.ops.geometry.color_attribute_convert.poll():
                             bpy.ops.geometry.color_attribute_convert(domain='POINT', data_type='FLOAT_COLOR')
-                            obj.data.update()  # Force mesh data update
+                            obj.data.update()
 
                         self.escape_object_name(obj)
                         self.exportGoZ(context.scene, obj, f'{PATH_PROJECT}')
@@ -687,7 +625,6 @@ class GoB_OT_export(Operator):
 
                 else:
                     ui.ShowReport(self, [obj.type, obj.name], "GoB: unsupported obj.type found:", 'COLORSET_01_VEC')
-                    # print("GoB: unsupported obj.type found:", obj.type, obj.name)
 
                 wm.progress_update(step * i)
             wm.progress_end()
@@ -697,7 +634,6 @@ class GoB_OT_export(Operator):
         except Exception as e:
             print(e)
 
-        # only run if PATH_OBJLIST file file is not empty, else zbrush errors
         if not paths.is_file_empty(paths.PATH_OBJLIST):
             path_exists = paths.find_zbrush(self, context, paths.isMacOS)
             if utils.prefs().export_run_zbrush:
@@ -707,22 +643,16 @@ class GoB_OT_export(Operator):
                     if paths.isMacOS:
                         print("OSX Popen: ", utils.prefs().zbrush_exec)
                         Popen(['open', '-a', utils.prefs().zbrush_exec, paths.PATH_SCRIPT])
-                    else: #windows
+                    else:
                         print("Windows Popen: ", utils.prefs().zbrush_exec)
                         Popen([utils.prefs().zbrush_exec, paths.PATH_SCRIPT], shell=True)
 
-        # restore object context
         if context.object and currentContext:
             bpy.ops.object.mode_set(mode=currentContext)
 
         return {'FINISHED'}
 
     def escape_object_name(self, obj):
-        """
-        Escape object name so it can be used as a valid file name.
-        Keep only alphanumeric characters, underscore, dash and dot, and replace other characters with an underscore.
-        Multiple consecutive invalid characters will be replaced with just a single underscore character.
-        """
         import re
         suffix_pattern = '\.(.*)'
         found_string = re.search(suffix_pattern, obj.name)
@@ -733,10 +663,6 @@ class GoB_OT_export(Operator):
         new_name = new_name.strip('_')
 
         if found_string:
-            # suffixes in zbrush longer than 1 symbol after a . (dot) require a specal addition
-            # of symbol+underline to be exported from zbrush, otherwise the whole suffix gets removed.
-            # Due to the complicated name that this would create, only the . (dot) for one symbol suffix are kept,
-            # the others are going to be replaced by a _ (underline) resulting from .001 to _001
             if len(found_string.group()) > 2:
                 new_name = re.sub(r'\.', '_', new_name)
 
@@ -745,8 +671,8 @@ class GoB_OT_export(Operator):
         elif not new_name:
             new_name = "Object"
         i = 0
-        while new_name in bpy.data.objects.keys(): #while name collision with other scene objs,
-            name_cut = None if i == 0 else -2  #in first loop, do not slice name.
-            new_name = new_name[:name_cut] + str(i).zfill(2) #add two latters to end of obj name.
+        while new_name in bpy.data.objects.keys():
+            name_cut = None if i == 0 else -2
+            new_name = new_name[:name_cut] + str(i).zfill(2)
             i += 1
         obj.name = new_name


### PR DESCRIPTION
Fix losing sculpt_face_sets and sculpt_mask attributes when objects are converted to bmeshes by writing the attribute data to the bmesh as a custom integer layer.

Also includes changes from pull request https://github.com/JoseConseco/GoB/pull/573 that fixes artifacts in meshes that occur when ngons along edges are triangulated and then merged back into quads. As well as a fix for UV map discrepencies that occured on meshes with mixed tri and quad geometry,