### PR TITLE
Add platform-specific paths for Windows and macOS

### DIFF
--- a/gob_export.py
+++ b/gob_export.py
@@ -44,7 +44,7 @@ class GoB_OT_export(Operator):
         return geometry.export_poll(cls, context)
 
     def exportGoZ(self, scn, obj, path_export):
-        PATH_PROJECT = utils.prefs().project_path
+        PATH_PROJECT = utils.get_project_path()
         if utils.prefs().performance_profiling:
             print("\n", 100*"=")
             start_time = utils.profiler(time.perf_counter(), "Export Profiling: " + obj.name)
@@ -117,7 +117,7 @@ class GoB_OT_export(Operator):
 
             # 6: Project Path
             GoBVars.write(pack('<2B',0x00, 0x53))   #.S
-            name = utils.prefs().project_path
+            name = utils.get_project_path()
             GoBVars.write(name.encode('utf-8'))
             if utils.prefs().performance_profiling:
                 start_time = utils.profiler(start_time, "    variablesFile: Write Project Path")
@@ -521,9 +521,9 @@ class GoB_OT_export(Operator):
     def execute(self, context):
 
         if utils.prefs().custom_pixologoc_path:
-            paths.PATH_GOZ =  utils.prefs().pixologoc_path
+            paths.PATH_GOZ = utils.get_pixologic_path()
 
-        PATH_PROJECT = utils.prefs().project_path
+        PATH_PROJECT = utils.get_project_path()
 
         try:
             source_GoZ_Info = os.path.join(paths.PATH_GOB, "Blender")
@@ -647,12 +647,13 @@ class GoB_OT_export(Operator):
                 if not path_exists:
                     bpy.ops.gob.search_zbrush('INVOKE_DEFAULT')
                 else:
+                    zbrush_exec = utils.get_zbrush_exec()
                     if paths.isMacOS:
-                        print("OSX Popen: ", utils.prefs().zbrush_exec)
-                        Popen(['open', '-a', utils.prefs().zbrush_exec, paths.PATH_SCRIPT])
+                        print("OSX Popen: ", zbrush_exec)
+                        Popen(['open', '-a', zbrush_exec, paths.PATH_SCRIPT])
                     else:
-                        print("Windows Popen: ", utils.prefs().zbrush_exec)
-                        Popen([utils.prefs().zbrush_exec, paths.PATH_SCRIPT], shell=True)
+                        print("Windows Popen: ", zbrush_exec)
+                        Popen([zbrush_exec, paths.PATH_SCRIPT], shell=True)
 
         if context.object and currentContext:
             bpy.ops.object.mode_set(mode=currentContext)

--- a/gob_import.py
+++ b/gob_import.py
@@ -781,7 +781,7 @@ class GoB_OT_import(Operator):
     def execute(self, context):
 
         if utils.prefs().custom_pixologoc_path:
-            paths.PATH_GOZ = utils.prefs().pixologoc_path
+            paths.PATH_GOZ = utils.get_pixologic_path()
 
         global gob_import_cache
         goz_obj_paths = []

--- a/paths.py
+++ b/paths.py
@@ -67,46 +67,54 @@ isMacOS, PATH_GOB, PATH_BLENDER, PATH_GOZ, PATH_OBJLIST, PATH_CONFIG, PATH_SCRIP
 
 def find_zbrush(self, context, isMacOS):
     #get the highest version of zbrush and use it as default zbrush to send to
-    self.is_found = False 
-    if utils.prefs().zbrush_exec:        
+    self.is_found = False
+    zbrush_exec = utils.get_zbrush_exec()
+    if zbrush_exec:
         #OSX .app files are considered packages and cant be recognized with path.isfile and needs a special condition
         if isMacOS:
-            if os.path.isdir(utils.prefs().zbrush_exec) and 'zbrush.app' in str.lower(utils.prefs().zbrush_exec):
+            if os.path.isdir(zbrush_exec) and 'zbrush.app' in str.lower(zbrush_exec):
                 self.is_found = True   
 
         else: #is PC
-            if os.path.isfile(utils.prefs().zbrush_exec):  #validate if working file here    
+            if os.path.isfile(zbrush_exec):  #validate if working file here
                 #check if path contains zbrush, that should identify a zbrush executable
-                if 'zbrush.exe' in str.lower(utils.prefs().zbrush_exec): 
+                if 'zbrush.exe' in str.lower(zbrush_exec):
                     self.is_found = True
 
-            elif os.path.isdir(utils.prefs().zbrush_exec): #search for zbrush files in this folder and its subfolders 
-                for folder in os.listdir(utils.prefs().zbrush_exec): 
+            elif os.path.isdir(zbrush_exec): #search for zbrush files in this folder and its subfolders
+                for folder in os.listdir(zbrush_exec):
                     if "zbrush" in str.lower(folder):     #search for content inside folder that contains zbrush
                         #search subfolders for executables
-                        if os.path.isdir(os.path.join(utils.prefs().zbrush_exec, folder)): 
-                            i,zfolder = utils.max_list_value(os.listdir(os.path.join(utils.prefs().zbrush_exec)))
-                            for file in os.listdir(os.path.join(utils.prefs().zbrush_exec, zfolder)):
-                                if ('zbrush.exe' in str.lower(file) in str.lower(file)):            
-                                    utils.prefs().zbrush_exec = os.path.join(utils.prefs().zbrush_exec, zfolder, file)           
-                                    self.is_found = True   
+                        if os.path.isdir(os.path.join(zbrush_exec, folder)):
+                            i,zfolder = utils.max_list_value(os.listdir(zbrush_exec))
+                            for file in os.listdir(os.path.join(zbrush_exec, zfolder)):
+                                if ('zbrush.exe' in str.lower(file) in str.lower(file)):
+                                    utils.set_zbrush_exec(os.path.join(zbrush_exec, zfolder, file))
+                                    self.is_found = True
 
                         #find executable
-                        if os.path.isfile(os.path.join(utils.prefs().zbrush_exec,folder)) and ('zbrush.exe' in str.lower(folder) in str.lower(folder)):            
-                            utils.prefs().zbrush_exec = os.path.join(utils.prefs().zbrush_exec, folder)           
-                            self.is_found = True  
+                        if os.path.isfile(os.path.join(zbrush_exec,folder)) and ('zbrush.exe' in str.lower(folder) in str.lower(folder)):
+                            utils.set_zbrush_exec(os.path.join(zbrush_exec, folder))
+                            self.is_found = True
 
-    else:    # the  applications default path can try if zbrush is installed in its defaut location  
+    if not self.is_found:  # try the default location when the configured path is empty or invalid
         #look for zbrush in default installation path 
         if isMacOS:
             folder_List = []                 
-            filepath = os.path.join("Applications")
+            filepath = os.path.join(os.sep, "Applications")
             if os.path.isdir(filepath):
                 [folder_List.append(i) for i in os.listdir(filepath) if 'zbrush' in str.lower(i)]
-                i, zfolder = utils.max_list_value(folder_List)
-                utils.prefs().zbrush_exec = os.path.join(filepath, zfolder, "ZBrush.app")
-                ui.ShowReport(self, [utils.prefs().zbrush_exec], "GoB: Zbrush default installation found", 'COLORSET_03_VEC') 
-                self.is_found = True            
+                if folder_List:
+                    i, zfolder = utils.max_list_value(folder_List)
+                    zbrush_folder = os.path.join(filepath, zfolder)
+                    if zfolder.lower().endswith("zbrush.app"):
+                        zbrush_exec_path = zbrush_folder
+                    else:
+                        zbrush_exec_path = os.path.join(zbrush_folder, "ZBrush.app")
+                    if os.path.isdir(zbrush_exec_path):
+                        utils.set_zbrush_exec(zbrush_exec_path)
+                        ui.ShowReport(self, [zbrush_exec_path], "GoB: Zbrush default installation found", 'COLORSET_03_VEC')
+                        self.is_found = True
         else:              
             # Determine the base paths based on the preference setting
             if utils.prefs().use_pixologic_path:
@@ -127,8 +135,8 @@ def find_zbrush(self, context, isMacOS):
                 i, zfolder = utils.max_list_value(folder_list)
                 zbrush_exec_path = os.path.join(base_path, zfolder, "ZBrush.exe")
                 if os.path.isfile(zbrush_exec_path):
-                    utils.prefs().zbrush_exec = zbrush_exec_path
-                    ui.ShowReport(self, [utils.prefs().zbrush_exec], f"GoB: {zfolder} default installation found", 'COLORSET_03_VEC')
+                    utils.set_zbrush_exec(zbrush_exec_path)
+                    ui.ShowReport(self, [zbrush_exec_path], f"GoB: {zfolder} default installation found", 'COLORSET_03_VEC')
                     self.is_found = True
                     break
 
@@ -154,7 +162,7 @@ class GoB_OT_GoZ_Installer(Operator):
     def execute(self, context):
         """Install GoZ for Windows""" 
         if path_exists := find_zbrush(self, context, isMacOS):
-            path = os.path.dirname(utils.prefs().zbrush_exec)
+            path = os.path.dirname(utils.get_zbrush_exec())
             if isMacOS:
                 GOZ_INSTALLER = os.path.join(path, "Troubleshoot Help", "GoZ_for_ZBrush_Installer_OSX.app")
                 Popen(['open', '-a', GOZ_INSTALLER])  

--- a/preferences.py
+++ b/preferences.py
@@ -26,7 +26,7 @@ import bpy
 from bpy.props import BoolProperty, EnumProperty, FloatProperty, StringProperty
 from bpy.types import AddonPreferences
 
-from . import paths, ui
+from . import paths, ui, utils
 
 preferences_tabs = [
     ("OPTIONS", "Options", ""),
@@ -35,6 +35,13 @@ preferences_tabs = [
     ("DEBUG", "Debug", ""),
     ("HELP", "Troubleshooting", ""),
 ]
+
+MACOS_PIXOLOGIC_PATH = "/Users/Shared/Pixologic"
+WINDOWS_PIXOLOGIC_PATH = os.path.join(
+    os.environ.get("PUBLIC", "C:/Users/Public"), "Pixologic"
+).replace("\\", "/")
+MACOS_PROJECT_PATH = f"{MACOS_PIXOLOGIC_PATH}/GoZProjects/Default/"
+WINDOWS_PROJECT_PATH = f"{WINDOWS_PIXOLOGIC_PATH}/GoZProjects/Default/"
 
 
 class GoB_Preferences(AddonPreferences):
@@ -89,11 +96,35 @@ class GoB_Preferences(AddonPreferences):
     # GLOBAL
     zbrush_exec: StringProperty(
         name="ZBrush Path",
-        description="Select Zbrush executable (C:\Program Files\Pixologic\ZBrush\ZBrush.exe). "
+        description="Select the ZBrush application for the current operating system. "
         "\nIf not specified the system default for Zscript (.zsc) files will be used",
         subtype="FILE_PATH",
         default="",
-    )  # Default: ""
+    )
+
+    zbrush_exec_macos: StringProperty(
+        name="macOS ZBrush Path",
+        description="Select the ZBrush application for macOS",
+        subtype="FILE_PATH",
+        default="",
+    )
+    zbrush_exec_windows: StringProperty(
+        name="Windows ZBrush Path",
+        description="Select the ZBrush executable for Windows",
+        subtype="FILE_PATH",
+        default="",
+    )
+
+    show_macos_paths: BoolProperty(
+        name="Show macOS Paths",
+        default=False,
+        options={"SKIP_SAVE"},
+    )
+    show_windows_paths: BoolProperty(
+        name="Show Windows Paths",
+        default=True,
+        options={"SKIP_SAVE"},
+    )
 
     use_pixologic_path: BoolProperty(
         name="Find Pixologic Version",
@@ -124,6 +155,19 @@ class GoB_Preferences(AddonPreferences):
         default=PATH_GOZ,
     )  # Default: PATH_GOZ
 
+    pixologoc_path_macos: StringProperty(
+        name="macOS Pixologic Public Path",
+        description="Pixologic public folder used by ZBrush on macOS",
+        subtype="DIR_PATH",
+        default=MACOS_PIXOLOGIC_PATH,
+    )
+    pixologoc_path_windows: StringProperty(
+        name="Windows Pixologic Public Path",
+        description="Pixologic public folder used by ZBrush on Windows",
+        subtype="DIR_PATH",
+        default=WINDOWS_PIXOLOGIC_PATH,
+    )
+
     project_path: StringProperty(
         name="Project Path",
         description="Folder where Zbrush and Blender will store the exported content",
@@ -131,6 +175,19 @@ class GoB_Preferences(AddonPreferences):
         default=os.path.join(paths.PATH_GOZ, "GoZProjects", "Default/").replace(
             "\\", "/"
         ),
+    )
+
+    project_path_macos: StringProperty(
+        name="macOS Project Path",
+        description="Folder where ZBrush and Blender exchange files on macOS",
+        subtype="DIR_PATH",
+        default=MACOS_PROJECT_PATH,
+    )
+    project_path_windows: StringProperty(
+        name="Windows Project Path",
+        description="Folder where ZBrush and Blender exchange files on Windows",
+        subtype="DIR_PATH",
+        default=WINDOWS_PROJECT_PATH,
     )
 
     clean_project_path: BoolProperty(
@@ -492,15 +549,76 @@ class GoB_Preferences(AddonPreferences):
         box.use_property_split = True
         box.label(text="GoB General Options", icon="PREFERENCES")
         col = box.column(align=False)
-        col.prop(self, "use_pixologic_path")
-        col.prop(self, "zbrush_exec")
-        col.prop(self, "project_path")
 
-        col.prop(self, "custom_pixologoc_path")
+        utils.migrate_legacy_zbrush_exec(self)
+        utils.migrate_legacy_project_path(self)
         if self.custom_pixologoc_path:
-            col.prop(self, "pixologoc_path")
+            utils.migrate_legacy_pixologic_path(self)
 
-        col.prop(self, "clean_project_path")
+        paths_box = col.box()
+        paths_box.label(text="System Paths", icon="FILE_FOLDER")
+
+        windows_box = paths_box.box()
+        windows_header = windows_box.row(align=True)
+        windows_header.use_property_split = False
+        windows_header.prop(
+            self,
+            "show_windows_paths",
+            text="",
+            icon="TRIA_DOWN" if self.show_windows_paths else "TRIA_RIGHT",
+            icon_only=True,
+            emboss=False,
+        )
+        windows_header.label(text="Windows", translate=False)
+        if self.show_windows_paths:
+            windows_col = windows_box.column(align=True)
+            windows_col.prop(self, "use_pixologic_path", text="Prefer Pixologic Install")
+            windows_col.prop(
+                self, "zbrush_exec_windows", text="ZBrush path", translate=False
+            )
+            windows_col.prop(
+                self, "project_path_windows", text="Project path", translate=False
+            )
+            if self.custom_pixologoc_path:
+                windows_col.prop(
+                    self,
+                    "pixologoc_path_windows",
+                    text="Pixologic Public path",
+                    translate=False,
+                )
+
+        macos_box = paths_box.box()
+        macos_header = macos_box.row(align=True)
+        macos_header.use_property_split = False
+        macos_header.prop(
+            self,
+            "show_macos_paths",
+            text="",
+            icon="TRIA_DOWN" if self.show_macos_paths else "TRIA_RIGHT",
+            icon_only=True,
+            emboss=False,
+        )
+        macos_header.label(text="macOS", translate=False)
+        if self.show_macos_paths:
+            macos_col = macos_box.column(align=True)
+            macos_col.prop(
+                self, "zbrush_exec_macos", text="ZBrush path", translate=False
+            )
+            macos_col.prop(
+                self, "project_path_macos", text="Project path", translate=False
+            )
+            if self.custom_pixologoc_path:
+                macos_col.prop(
+                    self,
+                    "pixologoc_path_macos",
+                    text="Pixologic Public path",
+                    translate=False,
+                )
+
+        paths_box.prop(self, "custom_pixologoc_path")
+        paths_box.prop(self, "clean_project_path")
+
+        col.separator()
         col.prop(self, "remap_x_axis")
         col.prop(self, "flip_x_axis")
         col.prop(self, "remap_y_axis")

--- a/utils.py
+++ b/utils.py
@@ -21,11 +21,103 @@ import time
 import numpy
 import random
 import addon_utils
+import platform
 
 
 def prefs():
     user_preferences = bpy.context.preferences
     return user_preferences.addons[__package__].preferences 
+
+
+def platform_path_storage_key(property_name, system=None):
+    """Return the platform-specific storage key for a path preference."""
+    system = system or platform.system()
+    if system == "Darwin":
+        return f"{property_name}_macos"
+    if system == "Windows":
+        return f"{property_name}_windows"
+    return property_name
+
+
+def legacy_path_matches_platform(path, system=None):
+    """Reject a legacy path only when it clearly belongs to the other platform."""
+    normalized_path = path.strip().replace("\\", "/")
+    system = system or platform.system()
+    is_windows_drive = (
+        len(normalized_path) > 2
+        and normalized_path[0].isalpha()
+        and normalized_path[1:3] == ":/"
+    )
+    is_windows_unc = normalized_path.startswith("//")
+
+    if system == "Darwin":
+        return not (
+            normalized_path.lower().endswith(".exe")
+            or is_windows_drive
+            or is_windows_unc
+        )
+    if system == "Windows":
+        return not (
+            (normalized_path.startswith("/") and not is_windows_unc)
+            or normalized_path.lower().endswith(".app")
+        )
+    return True
+
+
+def get_platform_path(property_name, preferences=None, system=None):
+    preferences = preferences or prefs()
+    storage_key = platform_path_storage_key(property_name, system)
+
+    if storage_key == property_name or preferences.is_property_set(storage_key):
+        return getattr(preferences, storage_key)
+
+    legacy_path = getattr(preferences, property_name)
+    if legacy_path and legacy_path_matches_platform(legacy_path, system):
+        return legacy_path
+    return getattr(preferences, storage_key)
+
+
+def set_platform_path(property_name, value, preferences=None, system=None):
+    preferences = preferences or prefs()
+    setattr(preferences, platform_path_storage_key(property_name, system), value)
+
+
+def migrate_legacy_platform_path(property_name, preferences, system=None):
+    storage_key = platform_path_storage_key(property_name, system)
+    if storage_key == property_name or preferences.is_property_set(storage_key):
+        return
+
+    legacy_path = getattr(preferences, property_name)
+    if legacy_path and legacy_path_matches_platform(legacy_path, system):
+        setattr(preferences, storage_key, legacy_path)
+
+
+def get_zbrush_exec(preferences=None, system=None):
+    return get_platform_path("zbrush_exec", preferences, system)
+
+
+def set_zbrush_exec(value, preferences=None, system=None):
+    set_platform_path("zbrush_exec", value, preferences, system)
+
+
+def migrate_legacy_zbrush_exec(preferences, system=None):
+    migrate_legacy_platform_path("zbrush_exec", preferences, system)
+
+
+def get_project_path(preferences=None, system=None):
+    return get_platform_path("project_path", preferences, system)
+
+
+def migrate_legacy_project_path(preferences, system=None):
+    migrate_legacy_platform_path("project_path", preferences, system)
+
+
+def get_pixologic_path(preferences=None, system=None):
+    return get_platform_path("pixologoc_path", preferences, system)
+
+
+def migrate_legacy_pixologic_path(preferences, system=None):
+    migrate_legacy_platform_path("pixologoc_path", preferences, system)
 
 
 def gob_version():
@@ -65,4 +157,4 @@ def profiler(start_time=False, string=None):
         print("debug_profiling: ", string)          
              
     start_time = time.perf_counter()
-    return start_time  
+    return start_time


### PR DESCRIPTION
## Motivation

Some users work with the same Blender/GoB configuration on both Windows and macOS. The current single ZBrush, GoZ project, and Pixologic public path fields cannot represent both operating systems at once: switching systems leaves GoB with paths that only exist on the other OS.

This also needs to be backward-compatible. Existing users should not have to re-enter their current GoB paths after updating, so legacy single-path preferences are detected by path style and migrated to the matching platform-specific field.

## Changes

- Store separate Windows and macOS values for the ZBrush executable, GoZ project directory, and optional Pixologic public directory.
- Use only the current platform's values at runtime while keeping both systems' values available in preferences.
- Keep the legacy preference properties and migrate matching saved values into the new platform-specific properties.
- Group Windows and macOS settings into foldout sections; Windows is shown first and expanded by default.
- Fall back to the platform's normal ZBrush discovery when a configured executable no longer exists.
- Correct macOS discovery to search `/Applications` and accept a direct `ZBrush.app` result.

## Validation

- Blender 5.2.0 LTS with an isolated official-extension installation.
- Platform selection and legacy migration assertions, including Windows drive-letter paths, UNC paths, macOS paths, project/public path defaults, invalid-path fallback, and foldout UI behavior.
- Extension register/unregister/register smoke test.
- Blender extension source audit, official package build, and package validation.

Windows path behavior was exercised through platform-selection tests; the isolated Blender runtime validation was performed on macOS.
